### PR TITLE
Refine onboarding experience and add Intl plural rules polyfill

### DIFF
--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { ScrollView, TextInput, Text, View } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, Pressable, ScrollView, Text, TextInput, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import * as Location from 'expo-location';
 import clsx from 'clsx';
@@ -9,16 +9,30 @@ import { Heading, Body } from '@/components/Typography';
 import { Button } from '@/components/Button';
 import { PRAYER_ORDER } from '@/constants/prayer';
 import { useAppContext } from '@/contexts/AppContext';
-import { calculateInitialEstimate } from '@/utils/calculations';
+import { calculateInitialEstimate, todayISO } from '@/utils/calculations';
 import { PrayerName } from '@/types';
-import { todayISO } from '@/utils/calculations';
 import { useRouter } from 'expo-router';
 
+type DurationUnit = 'days' | 'months' | 'years';
+
+type Coordinates = {
+  latitude: number;
+  longitude: number;
+};
+
+const totalSteps = 2;
+
+const getFallbackLabel = ({ latitude, longitude }: Coordinates) =>
+  `${latitude.toFixed(3)}, ${longitude.toFixed(3)}`;
+
 const OnboardingScreen: React.FC = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const router = useRouter();
-  const { completeOnboarding, updateLocation, settings } = useAppContext();
-  const [years, setYears] = useState('0');
+  const { completeOnboarding, updateLocation, settings, setLanguage } = useAppContext();
+
+  const [step, setStep] = useState<'duration' | 'breakdown'>('duration');
+  const [durationUnit, setDurationUnit] = useState<DurationUnit>('years');
+  const [durationValue, setDurationValue] = useState('1');
   const [counts, setCounts] = useState<Record<PrayerName, string>>({
     fajr: '0',
     dhuhr: '0',
@@ -28,22 +42,44 @@ const OnboardingScreen: React.FC = () => {
   });
   const [hasAdjusted, setHasAdjusted] = useState(false);
   const [loadingLocation, setLoadingLocation] = useState(false);
+  const [resolvingAddress, setResolvingAddress] = useState(false);
+  const [locationLabel, setLocationLabel] = useState<string | null>(null);
+  const [locationError, setLocationError] = useState<string | null>(null);
+
+  const isDark = settings?.theme === 'dark';
+
+  const durationInYears = useMemo(() => {
+    const value = parseFloat(durationValue.replace(',', '.'));
+    if (Number.isNaN(value) || value < 0) return 0;
+    switch (durationUnit) {
+      case 'days':
+        return value / 365;
+      case 'months':
+        return (value * 30) / 365;
+      default:
+        return value;
+    }
+  }, [durationValue, durationUnit]);
+
+  const perPrayer = useMemo(() => Math.max(Math.round(durationInYears * 365), 0), [durationInYears]);
+  const totalEstimate = useMemo(() => calculateInitialEstimate(durationInYears), [durationInYears]);
+
+  const applyBaseCounts = useCallback(() => {
+    const value = String(perPrayer);
+    setCounts({
+      fajr: value,
+      dhuhr: value,
+      asr: value,
+      maghrib: value,
+      isha: value
+    });
+  }, [perPrayer]);
 
   useEffect(() => {
-    if (hasAdjusted) return;
-    const numericYears = Number(years);
-    if (Number.isNaN(numericYears) || numericYears < 0) return;
-    const perPrayer = Math.round(numericYears * 365);
-    setCounts({
-      fajr: String(perPrayer),
-      dhuhr: String(perPrayer),
-      asr: String(perPrayer),
-      maghrib: String(perPrayer),
-      isha: String(perPrayer)
-    });
-  }, [years, hasAdjusted]);
-
-  const totalEstimate = useMemo(() => calculateInitialEstimate(Number(years)), [years]);
+    if (!hasAdjusted) {
+      applyBaseCounts();
+    }
+  }, [applyBaseCounts, hasAdjusted]);
 
   const handleCountChange = (prayer: PrayerName, value: string) => {
     setHasAdjusted(true);
@@ -52,29 +88,92 @@ const OnboardingScreen: React.FC = () => {
 
   const resetAdjustments = () => {
     setHasAdjusted(false);
-    const numericYears = Number(years);
-    const perPrayer = Math.round(numericYears * 365);
-    setCounts({
-      fajr: String(perPrayer),
-      dhuhr: String(perPrayer),
-      asr: String(perPrayer),
-      maghrib: String(perPrayer),
-      isha: String(perPrayer)
-    });
+    applyBaseCounts();
   };
+
+  const handleLanguageSelect = async (language: 'en' | 'ar') => {
+    if (settings?.language === language) return;
+    await setLanguage(language);
+    await i18n.changeLanguage(language);
+  };
+
+  const fetchLocationLabel = useCallback(async (coords: Coordinates) => {
+    try {
+      const geocoded = await Location.reverseGeocodeAsync(coords);
+      const place = geocoded[0];
+      if (!place) {
+        return getFallbackLabel(coords);
+      }
+      const { name, city, subregion, region, country } = place;
+      const parts = [name, city, subregion, region, country].filter(
+        (part, index, array) => part && array.indexOf(part) === index
+      ) as string[];
+      return parts.length > 0 ? parts.join(', ') : getFallbackLabel(coords);
+    } catch {
+      return getFallbackLabel(coords);
+    }
+  }, []);
+
+  useEffect(() => {
+    let isCancelled = false;
+    const lookup = async () => {
+      const coords = settings?.location;
+      if (!coords) {
+        setLocationLabel(null);
+        setResolvingAddress(false);
+        return;
+      }
+      setResolvingAddress(true);
+      try {
+        const label = await fetchLocationLabel(coords);
+        if (!isCancelled) {
+          setLocationLabel(label);
+          setLocationError(null);
+        }
+      } finally {
+        if (!isCancelled) {
+          setResolvingAddress(false);
+        }
+      }
+    };
+    lookup();
+    return () => {
+      isCancelled = true;
+    };
+  }, [settings?.location?.latitude, settings?.location?.longitude, fetchLocationLabel]);
 
   const requestLocation = async () => {
     try {
       setLoadingLocation(true);
+      setResolvingAddress(true);
+      setLocationError(null);
       const permission = await Location.requestForegroundPermissionsAsync();
       if (permission.status !== Location.PermissionStatus.GRANTED) {
+        setLocationError(t('onboarding.locationDenied'));
         return;
       }
       const loc = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Lowest });
-      await updateLocation({ latitude: loc.coords.latitude, longitude: loc.coords.longitude });
+      const coords: Coordinates = {
+        latitude: loc.coords.latitude,
+        longitude: loc.coords.longitude
+      };
+      await updateLocation(coords);
+      const label = await fetchLocationLabel(coords);
+      setLocationLabel(label);
+    } catch (error) {
+      setLocationError(t('onboarding.locationError'));
     } finally {
       setLoadingLocation(false);
+      setResolvingAddress(false);
     }
+  };
+
+  const handleNext = () => {
+    setStep('breakdown');
+  };
+
+  const handleBack = () => {
+    setStep('duration');
   };
 
   const handleContinue = async () => {
@@ -89,60 +188,203 @@ const OnboardingScreen: React.FC = () => {
     router.replace('/(tabs)/home');
   };
 
+  const stepIndex = step === 'duration' ? 1 : 2;
+  const languageOptions: Array<{ code: 'en' | 'ar'; label: string }> = [
+    { code: 'en', label: t('settings.english') },
+    { code: 'ar', label: t('settings.arabic') }
+  ];
+
+  const currentLocationText = locationError
+    ? locationError
+    : loadingLocation || resolvingAddress
+    ? t('onboarding.acquiringLocation')
+    : locationLabel
+    ? locationLabel
+    : t('onboarding.locationUnknown');
+
   return (
     <ScreenContainer>
       <ScrollView contentContainerStyle={{ paddingBottom: 40 }} showsVerticalScrollIndicator={false}>
         <Card>
+          <View className="mb-6 rounded-3xl border border-olive/20 bg-white/70 p-4 dark:border-white/10 dark:bg-white/5">
+            <Text className="text-xs uppercase tracking-[2px] text-olive/70 dark:text-white/60">
+              {t('onboarding.languagePrompt')}
+            </Text>
+            <View className="mt-3 flex-row gap-3">
+              {languageOptions.map((option) => {
+                const isActive = settings?.language === option.code;
+                return (
+                  <Pressable
+                    key={option.code}
+                    onPress={() => handleLanguageSelect(option.code)}
+                    className={clsx(
+                      'flex-1 rounded-2xl px-4 py-3 items-center justify-center border',
+                      isActive
+                        ? 'border-teal bg-teal'
+                        : isDark
+                        ? 'border-white/20 bg-transparent'
+                        : 'border-olive/30 bg-transparent'
+                    )}
+                  >
+                    <Text
+                      className={clsx(
+                        'font-semibold text-sm',
+                        isActive ? 'text-white' : isDark ? 'text-white/80' : 'text-teal'
+                      )}
+                    >
+                      {option.label}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+          </View>
+
+          <View className="mb-4">
+            <Text className="text-xs uppercase tracking-[2px] text-olive/70 dark:text-white/60">
+              {t('onboarding.stepLabel', { current: stepIndex, total: totalSteps })}
+            </Text>
+            <View className="mt-3 flex-row gap-2">
+              {Array.from({ length: totalSteps }).map((_, index) => (
+                <View
+                  key={index}
+                  className={clsx(
+                    'h-1 flex-1 rounded-full',
+                    index < stepIndex ? 'bg-teal' : 'bg-olive/30 dark:bg-white/20'
+                  )}
+                />
+              ))}
+            </View>
+          </View>
+
           <Heading className="mb-2 text-3xl">{t('onboarding.title')}</Heading>
           <Body className="mb-6">{t('onboarding.subtitle')}</Body>
 
-          <View className="mb-6">
-            <Text className="mb-2 text-teal/70">{t('onboarding.yearsLabel')}</Text>
-            <TextInput
-              keyboardType="numeric"
-              value={years}
-              onChangeText={setYears}
-              className={clsx(
-                'rounded-2xl border border-olive/40 px-4 py-3 text-teal text-lg',
-                settings?.theme === 'dark' && 'border-white/20 text-white'
-              )}
-            />
-            <Body className="mt-3">
-              {t('onboarding.calculate', { count: totalEstimate.toLocaleString() })}
-            </Body>
-          </View>
+          {step === 'duration' ? (
+            <>
+              <Text className="mb-2 text-sm font-semibold uppercase tracking-wide text-olive/70 dark:text-white/70">
+                {t('onboarding.durationLabel')}
+              </Text>
+              <View className="mb-4 rounded-3xl border border-olive/20 bg-white/70 p-4 dark:border-white/10 dark:bg-white/5">
+                <TextInput
+                  keyboardType="decimal-pad"
+                  value={durationValue}
+                  onChangeText={setDurationValue}
+                  placeholder="0"
+                  placeholderTextColor={isDark ? '#6b7280' : '#94a3b8'}
+                  className={clsx(
+                    'rounded-2xl border border-olive/30 px-4 py-3 text-lg text-teal',
+                    isDark && 'border-white/20 text-white bg-transparent'
+                  )}
+                />
+                <Body className="mt-3">{t('onboarding.durationHint')}</Body>
+                <View className="mt-4 flex-row gap-3">
+                  {(['days', 'months', 'years'] as DurationUnit[]).map((unit) => {
+                    const active = durationUnit === unit;
+                    return (
+                      <Pressable
+                        key={unit}
+                        onPress={() => setDurationUnit(unit)}
+                        className={clsx(
+                          'flex-1 rounded-2xl border px-4 py-3 items-center justify-center',
+                          active
+                            ? 'border-teal bg-teal'
+                            : isDark
+                            ? 'border-white/20 bg-transparent'
+                            : 'border-olive/30 bg-transparent'
+                        )}
+                      >
+                        <Text
+                          className={clsx(
+                            'font-semibold text-sm',
+                            active ? 'text-white' : isDark ? 'text-white/80' : 'text-teal'
+                          )}
+                        >
+                          {t(`onboarding.unit${unit.charAt(0).toUpperCase() + unit.slice(1)}`)}
+                        </Text>
+                      </Pressable>
+                    );
+                  })}
+                </View>
+              </View>
 
-          <Body className="mb-4">{t('onboarding.adjust')}</Body>
+              <View className="mb-8 rounded-3xl border border-olive/20 bg-olive/10 p-4 dark:border-white/10 dark:bg-white/10">
+                <Text className="text-sm font-medium text-teal dark:text-white">
+                  {t('onboarding.calculate', { count: totalEstimate.toLocaleString() })}
+                </Text>
+              </View>
 
-          {PRAYER_ORDER.map((prayer) => (
-            <View key={prayer} className="mb-3">
-              <Text className="mb-1 text-teal/70">{t(`prayers.${prayer}`)}</Text>
-              <TextInput
-                keyboardType="numeric"
-                value={counts[prayer]}
-                onChangeText={(value) => handleCountChange(prayer, value)}
-                className={clsx(
-                  'rounded-2xl border border-olive/30 px-4 py-3 text-teal',
-                  settings?.theme === 'dark' && 'border-white/20 text-white'
+              <Button title={t('onboarding.next')} onPress={handleNext} />
+            </>
+          ) : (
+            <>
+              <Body className="mb-4">{t('onboarding.adjust')}</Body>
+
+              {PRAYER_ORDER.map((prayer) => (
+                <View
+                  key={prayer}
+                  className="mb-3 rounded-3xl border border-olive/20 bg-white/70 p-4 dark:border-white/10 dark:bg-white/5"
+                >
+                  <Text className="mb-2 text-sm font-semibold uppercase tracking-wide text-olive/70 dark:text-white/70">
+                    {t(`prayers.${prayer}`)}
+                  </Text>
+                  <TextInput
+                    keyboardType="numeric"
+                    value={counts[prayer]}
+                    onChangeText={(value) => handleCountChange(prayer, value)}
+                    className={clsx(
+                      'rounded-2xl border border-olive/30 px-4 py-3 text-teal',
+                      isDark && 'border-white/20 text-white bg-transparent'
+                    )}
+                  />
+                </View>
+              ))}
+
+              <View className="mt-2 rounded-3xl border border-olive/20 bg-white/70 p-4 dark:border-white/10 dark:bg-white/5">
+                <Text className="mb-2 text-sm font-semibold uppercase tracking-wide text-olive/70 dark:text-white/70">
+                  {t('onboarding.locationReady')}
+                </Text>
+                <View className="flex-row items-center gap-3">
+                  <View className="flex-1">
+                    <Text
+                      className={clsx(
+                        'text-base',
+                        locationError
+                          ? 'text-rose-500'
+                          : isDark
+                          ? 'text-white'
+                          : 'text-teal'
+                      )}
+                    >
+                      {currentLocationText}
+                    </Text>
+                    {!locationError && (
+                      <Body className="mt-2 text-olive/70">
+                        {t('onboarding.locationPermission')}
+                      </Body>
+                    )}
+                  </View>
+                  {(loadingLocation || resolvingAddress) && (
+                    <ActivityIndicator color={isDark ? '#fff' : '#0f766e'} />
+                  )}
+                </View>
+                <View className="mt-4">
+                  <Button
+                    title={loadingLocation ? '…' : t('settings.updateLocation')}
+                    variant="secondary"
+                    onPress={requestLocation}
+                  />
+                </View>
+              </View>
+
+              <View className="mt-6 space-y-3">
+                <Button title={t('onboarding.continue')} onPress={handleContinue} />
+                <Button title={t('forms.back')} variant="secondary" onPress={handleBack} />
+                {hasAdjusted && (
+                  <Button title={t('onboarding.reset')} variant="secondary" onPress={resetAdjustments} />
                 )}
-              />
-            </View>
-          ))}
-
-          <View className="mb-2">
-            <Body>{t('onboarding.acquiringLocation')}</Body>
-            <Body className="mt-1 text-olive/70">{t('onboarding.locationPermission')}</Body>
-          </View>
-
-          <View className="flex-row justify-end items-center mb-8">
-            <Button title={loadingLocation ? '...' : t('settings.updateLocation')} variant="secondary" onPress={requestLocation} />
-          </View>
-
-          <Button title={t('onboarding.continue')} onPress={handleContinue} />
-          {hasAdjusted && (
-            <View className="mt-3">
-              <Button title={t('onboarding.reset')} variant="secondary" onPress={resetAdjustments} />
-            </View>
+              </View>
+            </>
           )}
         </Card>
       </ScrollView>

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -1,3 +1,4 @@
+import '@/polyfills/intlPluralRules';
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import * as Localization from 'expo-localization';
@@ -7,14 +8,25 @@ export const resources = {
     translation: {
       onboarding: {
         title: 'Missed Prayer Estimator',
-        subtitle: 'How many years of prayers do you think you missed?',
-        yearsLabel: 'Years without prayers',
+        subtitle: 'Start by telling us how long you have been away from prayer.',
+        languagePrompt: 'Choose the language you understand best.',
+        stepLabel: 'Step {{current}} of {{total}}',
+        durationLabel: 'How long have you missed prayers?',
+        durationHint: 'Select a value and timeframe below to personalise your plan.',
+        unitDays: 'Days',
+        unitMonths: 'Months',
+        unitYears: 'Years',
         calculate: 'That is roughly {{count}} prayers.',
-        adjust: 'Adjust by prayer if you know exact numbers.',
+        next: 'Next',
+        adjust: 'Fine-tune each prayer below if you know specific counts.',
         continue: 'Save and continue',
-        acquiringLocation: 'Fetching your location for prayer times…',
-        locationPermission: 'Allow location access to calculate prayer times automatically.',
-        reset: 'Reset adjustments'
+        reset: 'Reset adjustments',
+        acquiringLocation: 'Fetching your location for accurate prayer times…',
+        locationPermission: 'Allow location access to keep your schedule aligned with your city.',
+        locationReady: 'Detected location',
+        locationUnknown: 'Location not set yet.',
+        locationDenied: 'Location permission was denied. You can enable it in system settings.',
+        locationError: 'We could not determine your location. Please try again.'
       },
       dashboard: {
         greeting: 'Peace be upon you',
@@ -76,7 +88,8 @@ export const resources = {
       forms: {
         cancel: 'Cancel',
         confirm: 'Confirm',
-        done: 'Done'
+        done: 'Done',
+        back: 'Back'
       },
       notifications: {
         question: 'Did you pray {{prayer}}?',
@@ -92,14 +105,25 @@ export const resources = {
     translation: {
       onboarding: {
         title: 'تقدير الصلوات الفائتة',
-        subtitle: 'كم سنة تعتقد أنك تركت الصلاة؟',
-        yearsLabel: 'عدد السنوات',
+        subtitle: 'ابدأ بإخبارنا عن المدة التي تركت فيها الصلاة.',
+        languagePrompt: 'اختر اللغة الأنسب لك.',
+        stepLabel: 'الخطوة {{current}} من {{total}}',
+        durationLabel: 'كم مدة ترك الصلاة؟',
+        durationHint: 'أدخل القيمة واختر الإطار الزمني أدناه لتخصيص خطتك.',
+        unitDays: 'أيام',
+        unitMonths: 'أشهر',
+        unitYears: 'سنوات',
         calculate: 'يعادل تقريباً {{count}} صلاة.',
-        adjust: 'عدّل لكل صلاة إذا عرفت الأعداد الدقيقة.',
+        next: 'التالي',
+        adjust: 'يمكنك تعديل عدد كل صلاة إذا كنت تعرف الأعداد الدقيقة.',
         continue: 'حفظ ومتابعة',
-        acquiringLocation: 'جاري تحديد موقعك لأوقات الصلاة…',
-        locationPermission: 'اسمح بالوصول للموقع لحساب أوقات الصلاة تلقائياً.',
-        reset: 'إعادة التعيين'
+        reset: 'إعادة التعيين',
+        acquiringLocation: 'جاري تحديد موقعك لأوقات صلاة أدق…',
+        locationPermission: 'اسمح بالوصول للموقع لضبط الجدول حسب مدينتك.',
+        locationReady: 'تم تحديد الموقع',
+        locationUnknown: 'لم يتم تعيين الموقع بعد.',
+        locationDenied: 'تم رفض إذن الموقع. يمكنك تفعيله من إعدادات الجهاز.',
+        locationError: 'تعذر تحديد موقعك. حاول مرة أخرى.'
       },
       dashboard: {
         greeting: 'السلام عليكم',
@@ -161,7 +185,8 @@ export const resources = {
       forms: {
         cancel: 'إلغاء',
         confirm: 'تأكيد',
-        done: 'تم'
+        done: 'تم',
+        back: 'رجوع'
       },
       notifications: {
         question: 'هل صليت {{prayer}}؟',

--- a/src/polyfills/intlPluralRules.ts
+++ b/src/polyfills/intlPluralRules.ts
@@ -1,0 +1,67 @@
+const localeRules: Record<string, {
+  categories: string[];
+  select: (value: number) => string;
+}> = {
+  en: {
+    categories: ['one', 'other'],
+    select: (value: number) => {
+      return Math.abs(value) === 1 ? 'one' : 'other';
+    }
+  },
+  ar: {
+    categories: ['zero', 'one', 'two', 'few', 'many', 'other'],
+    select: (value: number) => {
+      const n = Math.abs(value);
+      const integer = Math.floor(n);
+      const fraction = n - integer;
+      if (fraction !== 0) return 'other';
+      const mod100 = integer % 100;
+      if (integer === 0) return 'zero';
+      if (integer === 1) return 'one';
+      if (integer === 2) return 'two';
+      if (mod100 >= 3 && mod100 <= 10) return 'few';
+      if (mod100 >= 11 && mod100 <= 99) return 'many';
+      return 'other';
+    }
+  }
+};
+
+const getLocaleConfig = (locale: string) => {
+  const normalized = locale.toLowerCase().split('-')[0];
+  return localeRules[normalized] ?? localeRules.en;
+};
+
+if (typeof globalThis.Intl === 'undefined') {
+  (globalThis as any).Intl = {};
+}
+
+if (typeof globalThis.Intl.PluralRules === 'undefined') {
+  class PluralRulesPolyfill {
+    private readonly locale: string;
+    private readonly type: 'cardinal' | 'ordinal';
+
+    constructor(locale: string | string[] = 'en', options?: { type?: 'cardinal' | 'ordinal' }) {
+      this.locale = Array.isArray(locale) ? locale[0] : locale;
+      this.type = options?.type ?? 'cardinal';
+      if (this.type !== 'cardinal') {
+        console.warn('PluralRules polyfill only supports cardinal numbers.');
+      }
+    }
+
+    select(value: number) {
+      const config = getLocaleConfig(this.locale);
+      return config.select(value);
+    }
+
+    resolvedOptions() {
+      const config = getLocaleConfig(this.locale);
+      return {
+        locale: this.locale,
+        pluralCategories: config.categories,
+        type: this.type
+      };
+    }
+  }
+
+  (globalThis.Intl as any).PluralRules = PluralRulesPolyfill;
+}


### PR DESCRIPTION
## Summary
- refresh the onboarding screen with a two-step flow, language selector, duration units, and location preview
- enhance translations for the revised onboarding copy in English and Arabic
- add an Intl.PluralRules polyfill to silence i18next warnings in environments without the API

## Testing
- npm run lint *(fails: ESLint could not find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d98da129c48326b84bae9e58c4b485