### PR TITLE
Add prayer times tab and refine logging workflow

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -26,6 +26,8 @@ const TabLayout: React.FC = () => {
           switch (route.name) {
             case 'home':
               return <Ionicons name="home" color={color} size={size} />;
+            case 'prayer-times':
+              return <Ionicons name="time" color={color} size={size} />;
             case 'logs':
               return <Ionicons name="book" color={color} size={size} />;
             case 'progress':
@@ -39,6 +41,7 @@ const TabLayout: React.FC = () => {
       })}
     >
       <Tabs.Screen name="home" options={{ title: t('dashboard.greeting') }} />
+      <Tabs.Screen name="prayer-times" options={{ title: t('prayerTimes.shortTitle') }} />
       <Tabs.Screen name="logs" options={{ title: t('logs.title') }} />
       <Tabs.Screen name="progress" options={{ title: t('progress.title') }} />
       <Tabs.Screen name="settings" options={{ title: t('settings.title') }} />

--- a/app/(tabs)/home.tsx
+++ b/app/(tabs)/home.tsx
@@ -18,13 +18,16 @@ const HomeScreen: React.FC = () => {
   const { t } = useTranslation();
   const router = useRouter();
   const { summaries, logs, addLog } = useAppContext();
-  const { prayerTimes, promptPrayer, setPromptPrayer, markMissed, logQadhaPrayer } = usePrayerTimes();
+  const {
+    promptPrayer,
+    setPromptPrayer,
+    markMissed,
+    logQadhaPrayer,
+    logCurrentPrayer,
+    locationDetails,
+    nextPrayer
+  } = usePrayerTimes();
   const [showForm, setShowForm] = useState(false);
-
-  const nextPrayer = useMemo(() => {
-    const now = dayjs();
-    return prayerTimes.find((pt) => dayjs(pt.time).isAfter(now));
-  }, [prayerTimes]);
 
   const todayLogs = useMemo(() => logs.filter((log) => log.date === todayISO()), [logs]);
 
@@ -49,7 +52,16 @@ const HomeScreen: React.FC = () => {
             {nextPrayer ? t(`prayers.${nextPrayer.prayer}`) : t('dashboard.nextPrayer')}
           </Text>
           {nextPrayer && (
-            <Body className="mt-2">{dayjs(nextPrayer.time).format('h:mm A')}</Body>
+            <Body className="mt-2 text-olive/80">
+              {t('dashboard.nextPrayerAt', { time: dayjs(nextPrayer.time).format('h:mm A') })}
+            </Body>
+          )}
+          {locationDetails?.formatted && (
+            <Body className="mt-2 text-olive/70">
+              {t('dashboard.locationLine', {
+                location: locationDetails.formatted
+              })}
+            </Body>
           )}
         </View>
 
@@ -90,6 +102,7 @@ const HomeScreen: React.FC = () => {
         onClose={() => setPromptPrayer(null)}
         onMissed={markMissed}
         onQadha={logQadhaPrayer}
+        onOnTime={logCurrentPrayer}
       />
     </ScreenContainer>
   );

--- a/app/(tabs)/prayer-times.tsx
+++ b/app/(tabs)/prayer-times.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { ActivityIndicator, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import dayjs from 'dayjs';
+import { useRouter } from 'expo-router';
+import { ScreenContainer } from '@/components/ScreenContainer';
+import { Card } from '@/components/Card';
+import { Heading, Body } from '@/components/Typography';
+import { Button } from '@/components/Button';
+import { usePrayerTimes } from '@/hooks/usePrayerTimes';
+import { PRAYER_ORDER } from '@/constants/prayer';
+
+const PrayerTimesScreen: React.FC = () => {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const { prayerTimes, loadingLocation, error, locationDetails, nextPrayer } = usePrayerTimes();
+
+  return (
+    <ScreenContainer>
+      <Card>
+        <Heading className="mb-2 text-2xl">{t('prayerTimes.title')}</Heading>
+        {locationDetails?.formatted ? (
+          <Body className="text-olive/80">{t('prayerTimes.location', { location: locationDetails.formatted })}</Body>
+        ) : (
+          <Body className="text-olive/80">{t('prayerTimes.locationUnknown')}</Body>
+        )}
+
+        <View className="my-5 rounded-3xl bg-white/60 p-4 shadow-sm shadow-black/5">
+          {loadingLocation ? (
+            <View className="flex-row items-center justify-center py-6">
+              <ActivityIndicator color="#7a8b71" />
+              <Body className="ml-3 text-olive/80">{t('prayerTimes.loading')}</Body>
+            </View>
+          ) : error ? (
+            <View className="py-4">
+              <Body className="text-red-500">{t(`prayerTimes.errors.${error}`)}</Body>
+            </View>
+          ) : (
+            PRAYER_ORDER.map((prayer) => {
+              const entry = prayerTimes.find((item) => item.prayer === prayer);
+              if (!entry) return null;
+              const isNext = nextPrayer && entry.prayer === nextPrayer.prayer;
+              return (
+                <View
+                  key={prayer}
+                  className={`mb-3 rounded-2xl px-4 py-3 ${
+                    isNext ? 'bg-teal/10 border border-teal/30' : 'bg-white/40'
+                  }`}
+                >
+                  <Body className={`text-lg font-semibold ${isNext ? 'text-teal' : 'text-teal/90'}`}>
+                    {t(`prayers.${prayer}`)}
+                  </Body>
+                  <Body className="text-olive/80">{dayjs(entry.time).format('h:mm A')}</Body>
+                  {isNext && (
+                    <Body className="mt-1 text-xs uppercase tracking-wide text-teal/70">
+                      {t('prayerTimes.upNext')}
+                    </Body>
+                  )}
+                </View>
+              );
+            })
+          )}
+        </View>
+
+        <Body className="mb-4 text-olive/70">{t('prayerTimes.updateHint')}</Body>
+        <Button
+          title={t('prayerTimes.manageLocation')}
+          variant="secondary"
+          onPress={() => router.push('/(tabs)/settings')}
+        />
+      </Card>
+    </ScreenContainer>
+  );
+};
+
+export default PrayerTimesScreen;

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -31,12 +31,14 @@ export const resources = {
       dashboard: {
         greeting: 'Peace be upon you',
         nextPrayer: 'Next prayer',
+        nextPrayerAt: 'Scheduled at {{time}}',
         totalRemaining: 'Missed prayers remaining',
         addLog: 'Log prayer',
         viewLogs: 'View logs',
         todaysProgress: "Today's progress",
         prayed: '{{count}} prayed',
-        missed: '{{count}} missed today'
+        missed: '{{count}} missed today',
+        locationLine: 'You are in {{location}}'
       },
       logs: {
         title: 'Prayer logs',
@@ -52,7 +54,12 @@ export const resources = {
         typeLabel: 'Type',
         timeLabel: 'Logged at',
         dateLabel: 'Date',
-        save: 'Save log'
+        save: 'Save log',
+        duplicateTitle: 'Already logged',
+        duplicateMessage: 'You have already logged this prayer today.',
+        errorTitle: 'Something went wrong',
+        errorMessage: 'We could not save this log. Please try again.',
+        singleCount: '1 prayer'
       },
       progress: {
         title: 'Progress',
@@ -76,7 +83,15 @@ export const resources = {
         large: 'Large',
         arabic: 'Arabic',
         english: 'English',
-        updateLocation: 'Update location'
+        updateLocation: 'Update location',
+        resolvingLocation: 'Resolving address…',
+        resetTitle: 'Reset all data?',
+        resetMessage: 'This will clear your progress and take you back to the start.',
+        resetCancel: 'Cancel',
+        resetConfirm: 'Reset',
+        resetDataTitle: 'Start over',
+        resetDataDescription: 'Clear every log and estimate to restart onboarding.',
+        resetButton: 'Reset app'
       },
       prayers: {
         fajr: 'Fajr',
@@ -95,9 +110,30 @@ export const resources = {
         question: 'Did you pray {{prayer}}?',
         no: 'No, add to missed',
         yes: 'Yes',
+        yesOnTime: 'Yes, prayed on time',
+        logQadha: 'Log qadha',
         qadhaQuestion: 'How many missed prayers did you repay?',
         submit: 'Save',
-        skip: 'Skip'
+        skip: 'Skip',
+        alreadyLoggedTitle: 'Already logged',
+        alreadyLoggedBody: 'You already logged {{prayer}} today.',
+        errorTitle: 'Could not save log',
+        errorBody: 'Please try again in a moment.'
+      },
+      prayerTimes: {
+        title: 'Prayer schedule',
+        shortTitle: 'Prayer times',
+        location: 'Based on {{location}}',
+        locationUnknown: 'Location not set yet.',
+        loading: 'Updating prayer times…',
+        errors: {
+          'location-permission': 'Allow location access in settings to get accurate times.',
+          'no-location': 'We could not detect your location. Try updating it from Settings.',
+          unknown: 'Something went wrong while fetching prayer times.'
+        },
+        upNext: 'Up next',
+        updateHint: 'Keep your location updated to ensure accurate times.',
+        manageLocation: 'Manage location'
       }
     }
   },
@@ -128,12 +164,14 @@ export const resources = {
       dashboard: {
         greeting: 'السلام عليكم',
         nextPrayer: 'الصلاة القادمة',
+        nextPrayerAt: 'موعدها {{time}}',
         totalRemaining: 'الصلاوات المتبقية',
         addLog: 'تسجيل صلاة',
         viewLogs: 'عرض السجل',
         todaysProgress: 'تقدم اليوم',
         prayed: '{{count}} صلوات أُديت',
-        missed: '{{count}} فاتت اليوم'
+        missed: '{{count}} فاتت اليوم',
+        locationLine: 'أنت في {{location}}'
       },
       logs: {
         title: 'سجل الصلوات',
@@ -149,7 +187,12 @@ export const resources = {
         typeLabel: 'النوع',
         timeLabel: 'الوقت',
         dateLabel: 'التاريخ',
-        save: 'حفظ السجل'
+        save: 'حفظ السجل',
+        duplicateTitle: 'مُسجل مسبقاً',
+        duplicateMessage: 'لقد سجلت هذه الصلاة اليوم بالفعل.',
+        errorTitle: 'حدث خطأ',
+        errorMessage: 'تعذر حفظ السجل. حاول مرة أخرى.',
+        singleCount: 'صلاة واحدة'
       },
       progress: {
         title: 'التقدم',
@@ -173,7 +216,15 @@ export const resources = {
         large: 'كبير',
         arabic: 'العربية',
         english: 'الإنجليزية',
-        updateLocation: 'تحديث الموقع'
+        updateLocation: 'تحديث الموقع',
+        resolvingLocation: 'جاري تحديد العنوان…',
+        resetTitle: 'إعادة تعيين جميع البيانات؟',
+        resetMessage: 'سيتم مسح تقدمك وإعادتك للبداية.',
+        resetCancel: 'إلغاء',
+        resetConfirm: 'إعادة',
+        resetDataTitle: 'البدء من جديد',
+        resetDataDescription: 'سيتم حذف السجلات والتقديرات للعودة للإعداد الأولي.',
+        resetButton: 'إعادة تعيين التطبيق'
       },
       prayers: {
         fajr: 'الفجر',
@@ -192,9 +243,30 @@ export const resources = {
         question: 'هل صليت {{prayer}}؟',
         no: 'لم أصلِّ، أضفها للفائتة',
         yes: 'نعم',
+        yesOnTime: 'نعم، في وقتها',
+        logQadha: 'تسجيل قضاء',
         qadhaQuestion: 'كم صلاة فائتة قضيت؟',
         submit: 'حفظ',
-        skip: 'تخطي'
+        skip: 'تخطي',
+        alreadyLoggedTitle: 'مُسجل مسبقاً',
+        alreadyLoggedBody: 'لقد سجلت {{prayer}} اليوم.',
+        errorTitle: 'تعذر حفظ السجل',
+        errorBody: 'حاول مرة أخرى لاحقاً.'
+      },
+      prayerTimes: {
+        title: 'جدول الصلاة',
+        shortTitle: 'أوقات الصلاة',
+        location: 'حسب {{location}}',
+        locationUnknown: 'لم يتم تعيين الموقع بعد.',
+        loading: 'جاري تحديث أوقات الصلاة…',
+        errors: {
+          'location-permission': 'فعّل إذن الموقع من الإعدادات للحصول على أوقات دقيقة.',
+          'no-location': 'تعذر تحديد موقعك. جرّب تحديثه من الإعدادات.',
+          unknown: 'حدث خطأ أثناء جلب أوقات الصلاة.'
+        },
+        upNext: 'الصلاة القادمة',
+        updateHint: 'حدّث موقعك باستمرار لضمان دقة الأوقات.',
+        manageLocation: 'إدارة الموقع'
       }
     }
   }

--- a/src/services/prayerTimes.ts
+++ b/src/services/prayerTimes.ts
@@ -17,12 +17,30 @@ const prayerMap: Record<PrayerName, keyof PrayerTimes> = {
   isha: 'isha'
 };
 
+const calculationMethodFactories: Partial<Record<CalculationMethod, () => CalculationParameters>> = {
+  [CalculationMethod.MuslimWorldLeague]: () => CalculationMethod.MuslimWorldLeague(),
+  [CalculationMethod.Egyptian]: () => CalculationMethod.Egyptian(),
+  [CalculationMethod.Karachi]: () => CalculationMethod.Karachi(),
+  [CalculationMethod.UmmAlQura]: () => CalculationMethod.UmmAlQura(),
+  [CalculationMethod.Dubai]: () => CalculationMethod.Dubai(),
+  [CalculationMethod.MoonsightingCommittee]: () => CalculationMethod.MoonsightingCommittee(),
+  [CalculationMethod.NorthAmerica]: () => CalculationMethod.NorthAmerica(),
+  [CalculationMethod.Kuwait]: () => CalculationMethod.Kuwait(),
+  [CalculationMethod.Qatar]: () => CalculationMethod.Qatar(),
+  [CalculationMethod.Singapore]: () => CalculationMethod.Singapore(),
+  [CalculationMethod.Tehran]: () => CalculationMethod.Tehran(),
+  [CalculationMethod.Turkey]: () => CalculationMethod.Turkey(),
+  [CalculationMethod.Other]: () => new CalculationParameters()
+};
+
 export const computePrayerTimes = (
   date: Date,
   coordinates: Coordinates,
   method: CalculationMethod = CalculationMethod.MuslimWorldLeague
 ): PrayerTimeResult[] => {
-  const params: CalculationParameters = CalculationMethod[CalculationMethod[method]];
+  const paramsFactory =
+    calculationMethodFactories[method] ?? calculationMethodFactories[CalculationMethod.MuslimWorldLeague];
+  const params: CalculationParameters = paramsFactory ? paramsFactory() : new CalculationParameters();
   params.madhab = Madhab.Hanafi;
   const times = new PrayerTimes(coordinates, date, params);
   return PRAYER_ORDER.map((prayer) => ({


### PR DESCRIPTION
## Summary
- fix prayer time calculation by using the adhan helpers and enrich prayer time data with location details
- show the user location and upcoming prayer on the home dashboard and add a dedicated prayer times tab
- streamline logging by removing counts for on-time prayers, preventing duplicate logs, and offering a full data reset in settings

## Testing
- npm run lint *(fails: ESLint requires an eslint.config.js migration)*

------
https://chatgpt.com/codex/tasks/task_e_68d9917669388326a528d0ab98875ce1