### PR TITLE
Refine prayer logs and prayer times UI

### DIFF
--- a/app/(tabs)/logs.tsx
+++ b/app/(tabs)/logs.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Alert, Pressable, ScrollView, Text, View } from 'react-native';
+import { Alert, Modal, Pressable, ScrollView, Text, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import dayjs from 'dayjs';
 import { ScreenContainer } from '@/components/ScreenContainer';
@@ -11,10 +11,11 @@ import { useAppContext } from '@/contexts/AppContext';
 import { groupLogsByDate, formatTimeForDisplay } from '@/utils/calculations';
 import { PrayerLog } from '@/types';
 import clsx from 'clsx';
+import { Ionicons } from '@expo/vector-icons';
 
 const LogsScreen: React.FC = () => {
   const { t } = useTranslation();
-  const { logs, addLog, editLog, removeLog } = useAppContext();
+  const { logs, addLog, editLog, removeLog, settings } = useAppContext();
   const [showForm, setShowForm] = useState(false);
   const [editing, setEditing] = useState<PrayerLog | null>(null);
 
@@ -24,6 +25,8 @@ const LogsScreen: React.FC = () => {
     [groupedLogs]
   );
   const [selectedDate, setSelectedDate] = useState<'all' | string>('all');
+  const [showDatePicker, setShowDatePicker] = useState(false);
+  const isDark = settings?.theme === 'dark';
 
   useEffect(() => {
     if (selectedDate !== 'all' && !dates.includes(selectedDate)) {
@@ -35,6 +38,18 @@ const LogsScreen: React.FC = () => {
     if (selectedDate === 'all') return dates;
     return dates.filter((date) => date === selectedDate);
   }, [dates, selectedDate]);
+
+  const dateLabel = useMemo(() => {
+    if (selectedDate === 'all') {
+      return t('logs.filterAll');
+    }
+    return dayjs(selectedDate).format('MMM D, YYYY');
+  }, [selectedDate, t]);
+
+  const handleSelectDate = (value: 'all' | string) => {
+    setSelectedDate(value);
+    setShowDatePicker(false);
+  };
 
   const handleAdd = () => {
     setEditing(null);
@@ -79,38 +94,103 @@ const LogsScreen: React.FC = () => {
 
       <ScrollView contentContainerStyle={{ paddingBottom: 120 }}>
         {dates.length > 0 && (
-          <Card className="mb-4 space-y-3 border border-olive/15 dark:border-white/10">
-            <View>
-              <Text className="mb-2 text-xs uppercase tracking-[2px] text-olive/60 dark:text-white/60">
-                {t('logs.filterLabel')}
-              </Text>
-              <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-                <View className="flex-row gap-2 pr-3">
-                  {(['all', ...dates] as Array<'all' | string>).map((value) => {
-                    const active = selectedDate === value;
-                    const label = value === 'all'
-                      ? t('logs.filterAll')
-                      : dayjs(value).format('MMM D');
-                    return (
-                      <Pressable
-                        key={value}
-                        onPress={() => setSelectedDate(value)}
-                        className={clsx(
-                          'rounded-full px-4 py-2',
-                          active ? 'bg-olive' : 'bg-olive/10 dark:bg-white/10'
-                        )}
-                      >
-                        <Text className={clsx('font-semibold', active ? 'text-white' : 'text-teal dark:text-white')}>
-                          {label}
-                        </Text>
-                      </Pressable>
-                    );
-                  })}
+          <>
+            <Pressable
+              onPress={() => setShowDatePicker(true)}
+              className={clsx(
+                'mb-4 flex-row items-center justify-between rounded-2xl border px-4 py-3',
+                isDark ? 'border-white/10 bg-white/5' : 'border-olive/20 bg-white/70 shadow-sm shadow-black/5'
+              )}
+              accessibilityRole="button"
+              accessibilityLabel={t('logs.filterLabel')}
+            >
+              <View className="flex-row items-center gap-3">
+                <Ionicons
+                  name="calendar-outline"
+                  size={18}
+                  color={isDark ? '#f4f4f5' : '#3e4c41'}
+                />
+                <Text className={clsx('font-semibold', isDark ? 'text-white' : 'text-teal')}>
+                  {dateLabel}
+                </Text>
+              </View>
+              <Ionicons
+                name="chevron-down"
+                size={18}
+                color={isDark ? '#e5e7eb' : '#6b7a70'}
+              />
+            </Pressable>
+
+            <Modal
+              visible={showDatePicker}
+              transparent
+              animationType="fade"
+              onRequestClose={() => setShowDatePicker(false)}
+            >
+              <View className="flex-1 justify-end bg-black/40">
+                <Pressable className="flex-1" onPress={() => setShowDatePicker(false)} accessible={false} />
+                <View
+                  className={clsx(
+                    'rounded-t-3xl px-5 pb-6 pt-4',
+                    isDark ? 'bg-[#1f2429]' : 'bg-white'
+                  )}
+                >
+                  <View className="mb-3 flex-row items-center justify-between">
+                    <Text className={clsx('text-lg font-semibold', isDark ? 'text-white' : 'text-teal')}>
+                      {t('logs.filterLabel')}
+                    </Text>
+                  </View>
+                  <View className="max-h-80">
+                    <ScrollView showsVerticalScrollIndicator={false}>
+                      {(['all', ...dates] as Array<'all' | string>).map((value) => {
+                        const active = selectedDate === value;
+                        const label =
+                          value === 'all' ? t('logs.filterAll') : dayjs(value).format('MMM D, YYYY');
+                        return (
+                          <Pressable
+                            key={value}
+                            onPress={() => handleSelectDate(value)}
+                            className={clsx(
+                              'flex-row items-center justify-between rounded-2xl px-4 py-3',
+                              active
+                                ? isDark
+                                  ? 'bg-teal/30'
+                                  : 'bg-olive/15'
+                                : isDark
+                                ? 'bg-white/5'
+                                : 'bg-white'
+                            )}
+                          >
+                            <Text
+                              className={clsx(
+                                'font-medium',
+                                isDark
+                                  ? active
+                                    ? 'text-white'
+                                    : 'text-white/70'
+                                  : active
+                                  ? 'text-teal'
+                                  : 'text-olive/70'
+                              )}
+                            >
+                              {label}
+                            </Text>
+                            {active && (
+                              <Ionicons
+                                name="checkmark"
+                                size={18}
+                                color={isDark ? '#22d3ee' : '#2f7a55'}
+                              />
+                            )}
+                          </Pressable>
+                        );
+                      })}
+                    </ScrollView>
+                  </View>
                 </View>
-              </ScrollView>
-            </View>
-            <Body className="text-sm text-olive/70 dark:text-white/60">{t('logs.filterHint')}</Body>
-          </Card>
+              </View>
+            </Modal>
+          </>
         )}
 
         {dates.length === 0 && (
@@ -130,59 +210,81 @@ const LogsScreen: React.FC = () => {
               </Text>
             </View>
             <View className="space-y-3">
-              {groupedLogs[date].map((log) => (
-                <View
-                  key={log.id}
-                  className="rounded-2xl border border-olive/20 bg-white/70 p-4 dark:border-white/10 dark:bg-white/5"
-                >
-                  <View className="flex-row items-center justify-between">
-                    <Body className="font-semibold">{t(`prayers.${log.prayer}`)}</Body>
-                    <Text className="text-xs font-semibold uppercase tracking-wide text-olive/70 dark:text-white/60">
-                      {formatTimeForDisplay(log.loggedAt)}
-                    </Text>
-                  </View>
-                  <View className="mt-2 flex-row items-center justify-between">
-                    <Body className="text-sm text-olive/80 dark:text-white/70">
-                      {log.type === 'current'
-                        ? t('logs.typeCurrent')
-                        : `${t('logs.typeQada')} · ${log.count}`}
-                    </Body>
-                    <View
-                      className={`rounded-full px-3 py-1 ${
-                        log.type === 'current'
-                          ? 'bg-emerald-500/10'
-                          : 'bg-amber-500/10'
-                      }`}
-                    >
-                      <Text
-                        className={`text-xs font-semibold uppercase tracking-wide ${
-                          log.type === 'current' ? 'text-emerald-600' : 'text-amber-600'
-                        }`}
-                      >
-                        {t(`logs.badge${log.type === 'current' ? 'Current' : 'Qada'}`)}
+              {groupedLogs[date].map((log) => {
+                const badgeBackground =
+                  log.type === 'current'
+                    ? isDark
+                      ? 'bg-emerald-500/20'
+                      : 'bg-emerald-500/10'
+                    : isDark
+                    ? 'bg-amber-500/20'
+                    : 'bg-amber-500/15';
+                const badgeText =
+                  log.type === 'current'
+                    ? isDark
+                      ? 'text-emerald-200'
+                      : 'text-emerald-600'
+                    : isDark
+                    ? 'text-amber-200'
+                    : 'text-amber-600';
+
+                return (
+                  <View
+                    key={log.id}
+                    className={clsx(
+                      'rounded-2xl border p-3',
+                      isDark ? 'border-white/10 bg-white/5' : 'border-olive/20 bg-white/70'
+                    )}
+                  >
+                    <View className="flex-row items-center justify-between">
+                      <Body className="font-semibold">{t(`prayers.${log.prayer}`)}</Body>
+                      <Text className="text-xs font-semibold uppercase tracking-wide text-olive/70 dark:text-white/60">
+                        {formatTimeForDisplay(log.loggedAt)}
                       </Text>
                     </View>
-                  </View>
-                  <View className="mt-3 flex-row gap-2">
-                    <View className="flex-1">
-                      <Button
-                        title={t('logs.edit')}
-                        variant="secondary"
-                        size="compact"
-                        onPress={() => handleEdit(log)}
-                      />
+                    <View className="mt-2 flex-row items-center justify-between">
+                      <View className="flex-row items-center gap-2">
+                        <Body className="text-sm text-olive/80 dark:text-white/70">
+                          {log.type === 'current'
+                            ? t('logs.typeCurrent')
+                            : `${t('logs.typeQada')} · ${log.count}`}
+                        </Body>
+                        <View className={clsx('rounded-full px-3 py-1', badgeBackground)}>
+                          <Text className={clsx('text-xs font-semibold uppercase tracking-wide', badgeText)}>
+                            {t(`logs.badge${log.type === 'current' ? 'Current' : 'Qada'}`)}
+                          </Text>
+                        </View>
+                      </View>
+                      <View className="flex-row items-center gap-2">
+                        <Pressable
+                          accessibilityRole="button"
+                          accessibilityLabel={t('logs.edit')}
+                          onPress={() => handleEdit(log)}
+                          className={clsx('rounded-full p-2', isDark ? 'bg-white/10' : 'bg-olive/15')}
+                        >
+                          <Ionicons
+                            name="create-outline"
+                            size={18}
+                            color={isDark ? '#f8fafc' : '#3f4f43'}
+                          />
+                        </Pressable>
+                        <Pressable
+                          accessibilityRole="button"
+                          accessibilityLabel={t('logs.delete')}
+                          onPress={() => handleDelete(log)}
+                          className={clsx('rounded-full p-2', isDark ? 'bg-red-500/20' : 'bg-red-100')}
+                        >
+                          <Ionicons
+                            name="trash-outline"
+                            size={18}
+                            color={isDark ? '#fca5a5' : '#b91c1c'}
+                          />
+                        </Pressable>
+                      </View>
                     </View>
-                    <View className="flex-1">
-                      <Button
-                        title={t('logs.delete')}
-                        variant="secondary"
-                        size="compact"
-                        onPress={() => handleDelete(log)}
-                      />
-                    </View>
                   </View>
-                </View>
-              ))}
+                );
+              })}
             </View>
           </Card>
         ))}

--- a/app/(tabs)/prayer-times.tsx
+++ b/app/(tabs)/prayer-times.tsx
@@ -9,11 +9,25 @@ import { Heading, Body } from '@/components/Typography';
 import { Button } from '@/components/Button';
 import { usePrayerTimes } from '@/hooks/usePrayerTimes';
 import { PRAYER_ORDER } from '@/constants/prayer';
+import { Ionicons } from '@expo/vector-icons';
+import clsx from 'clsx';
+import { useAppContext } from '@/contexts/AppContext';
+import { PrayerName } from '@/types';
+
+const PRAYER_ICONS: Record<PrayerName, keyof typeof Ionicons.glyphMap> = {
+  fajr: 'cloudy-night-outline',
+  dhuhr: 'sunny-outline',
+  asr: 'partly-sunny-outline',
+  maghrib: 'sunset-outline',
+  isha: 'moon-outline'
+};
 
 const PrayerTimesScreen: React.FC = () => {
   const { t } = useTranslation();
   const router = useRouter();
   const { prayerTimes, loadingLocation, error, locationDetails, nextPrayer } = usePrayerTimes();
+  const { settings } = useAppContext();
+  const isDark = settings?.theme === 'dark';
 
   return (
     <ScreenContainer>
@@ -43,19 +57,49 @@ const PrayerTimesScreen: React.FC = () => {
               return (
                 <View
                   key={prayer}
-                  className={`mb-3 rounded-2xl px-4 py-3 ${
-                    isNext ? 'bg-teal/10 border border-teal/30' : 'bg-white/40'
-                  }`}
-                >
-                  <Body className={`text-lg font-semibold ${isNext ? 'text-teal' : 'text-teal/90'}`}>
-                    {t(`prayers.${prayer}`)}
-                  </Body>
-                  <Body className="text-olive/80">{dayjs(entry.time).format('h:mm A')}</Body>
-                  {isNext && (
-                    <Body className="mt-1 text-xs uppercase tracking-wide text-teal/70">
-                      {t('prayerTimes.upNext')}
-                    </Body>
+                  className={clsx(
+                    'mb-3 rounded-2xl px-4 py-3',
+                    isNext
+                      ? 'border border-teal/40 bg-teal/10'
+                      : isDark
+                      ? 'bg-white/5'
+                      : 'bg-white/40'
                   )}
+                >
+                  <View className="flex-row items-center justify-between">
+                    <View className="flex-row items-center gap-3">
+                      <View
+                        className={clsx(
+                          'rounded-2xl p-2',
+                          isNext ? 'bg-teal/20' : isDark ? 'bg-white/10' : 'bg-olive/20'
+                        )}
+                      >
+                        <Ionicons
+                          name={PRAYER_ICONS[prayer]}
+                          size={20}
+                          color={isNext ? '#0f766e' : isDark ? '#f8fafc' : '#3f4f43'}
+                        />
+                      </View>
+                      <Body
+                        className={clsx(
+                          'font-semibold',
+                          isNext ? 'text-teal' : 'text-teal/90 dark:text-white'
+                        )}
+                      >
+                        {t(`prayers.${prayer}`)}
+                      </Body>
+                    </View>
+                    <View className="items-end">
+                      <Body className="text-lg font-semibold text-teal dark:text-white">
+                        {dayjs(entry.time).format('h:mm A')}
+                      </Body>
+                      {isNext && (
+                        <Body className="mt-1 text-xs font-semibold uppercase tracking-wide text-teal">
+                          {t('prayerTimes.upNext')}
+                        </Body>
+                      )}
+                    </View>
+                  </View>
                 </View>
               );
             })


### PR DESCRIPTION
## Summary
- streamline the prayer log filter into a single calendar field with a modal date picker
- tighten each prayer log card by pairing status badges with prayer type text and switching to icon actions
- enhance the prayer times list with contextual icons and refreshed layout treatment

## Testing
- npm run lint *(fails: existing repository-wide prettier rules trigger numerous warnings/errors)*

------
https://chatgpt.com/codex/tasks/task_e_68db0a054b448326a83b99d7f3e76323